### PR TITLE
Fix the State Machine tests

### DIFF
--- a/testing/test1.sh
+++ b/testing/test1.sh
@@ -3,25 +3,26 @@ echo '*** State Machine'
 
 state='ON'
 echo "Go to $state"
-caput $llrf_prefix $state > /dev/null
+caput -S $llrf_prefix:MSGS $state > /dev/null
 result="$(caget -t $llrf_prefix)"
 [ "$result" = "$state" ] && echo "Pass" || echo "***FAIL!!!***"
 
 state='RESETTING'
+msg='RESET'
 echo "Go to $state"
-caput $llrf_prefix $state > /dev/null
+caput -S $llrf_prefix:MSGS $msg > /dev/null
 result="$(caget -t $llrf_prefix)"
 [ "$result" = "$state" ] && echo "Pass" || echo "***FAIL!!!***"
 
 state='INIT'
 echo "Go to $state"
-caput $llrf_prefix $state > /dev/null
+caput -S $llrf_prefix:MSGS $state > /dev/null
 result="$(caget -t $llrf_prefix)"
 [ "$result" = "$state" ] && echo "Pass" || echo "***FAIL!!!***"
 
 state='ON'
 echo "Go to $state"
-caput $llrf_prefix $state > /dev/null
+caput -S $llrf_prefix:MSGS $state > /dev/null
 result="$(caget -t $llrf_prefix)"
 [ "$result" = "$state" ] && echo "Pass" || echo "***FAIL!!!***"
 


### PR DESCRIPTION
Now the test change the state machine correctly.

Note that the test with VM Output will not work without
the last PR from m-kmod-sis8300
(https://bitbucket.org/europeanspallationsource/m-kmod-sis8300/pull-requests/20)
and from m-epics-sis8300
https://bitbucket.org/europeanspallationsource/m-epics-sis8300/pull-requests/11
because the last state in the test script is ON