### PR TITLE
Simplify state_change command

### DIFF
--- a/testing/set_att
+++ b/testing/set_att
@@ -1,30 +1,22 @@
-if [ $1 = "-h" ] || [ $# -lt 1 ]; then
+if [ $1 = "-h" ] || [ $# -lt 3 ]; then
     echo "Writes an attenuation value to register for channels 0-8."
-    echo "Value parameter is optional and a random value in the valid range"
-    echo "is generated."
-    echo "usage: sh set_att <sis8300 slot> <channel> (value)"
-    echo "e.g. sh set-att 0 15" 
+    echo "usage: sh set_att <LLRF_INSTANCE> <sis8300 slot> <channel> <value> "
+    echo "e.g. sh set-att LLRF 0 15" 
     exit
 fi
 
-slot=$1
-channel=$2
-
-if [ $# -ge 3 ]; then
-    attVal = $3
-else
-    attVal=$(( 1 + (RANDOM % 30  / (1 + $channel / 8)) ))
-fi
+LLRF_INSTANCE=$1
+slot=$2
+channel=$3
+attVal=$4
 
 run() {
     eval "$(dirname $0)/$1"
 }
 
-
-
 state=$(( $attVal * 2 * (1 + $channel / 8) ))
 echo "Ch $channel - setting attenuation to $attVal"
-caput $LLRF_IOC_NAME:AI$channel-ATT $attVal > /dev/null
+caput $LLRF_INSTANCE:AI$channel-ATT $attVal > /dev/null
 # 4-byte registers 0xF82, 0xF83 and 0xF84 hold the values with one byte offsets between values
 reg="0xF8$(( 2 + $channel / 4 ))"
 result="$(sis8300drv_reg /dev/sis8300-$slot $reg)"

--- a/testing/state_change
+++ b/testing/state_change
@@ -1,6 +1,6 @@
-if [ $# -ne 1 ] ; then                              
-    echo "usage: sh state_change.sh <required state>"
-    echo "e.g. sh state_change.sh RESET"
+if [ $# -ne 2 ] ; then                              
+    echo "usage: sh state_change.sh <LLRF_INSTANCE> <required state>"
+    echo "e.g. sh state_change.sh LLRF-TS2-1-1 RESET"
     exit                                            
 fi         
 
@@ -8,14 +8,17 @@ run() {
     eval "$(dirname $0)/$1"
 }
 
-echo "Go to state $1"
-eval "caput -S $LLRF_IOC_NAME:MSGS $1 >/dev/null"
+LLRF_INSTANCE=$1
+req_state=$2
+
+echo "Go to state $req_state"
+eval "caput -S $LLRF_INSTANCE:MSGS $req_state >/dev/null"
 usleep 500000
-result=$(caget -t $LLRF_IOC_NAME)
-if [ $1 == 'RESET' ]; then 
+result=$(caget -t $LLRF_INSTANCE)
+if [ $req_state == 'RESET' ]; then 
 	# Special case when state request is 'RESET' as the expected new state is 'RESETTING', allow for this case.
-    run "check RESETTING $result Test state change to $1"
+    run "check RESETTING $result Test state change to $req_state"
 else
 	# The norman user case it that the state request matches the expected new state
-    run "check $1 $result Test state change to $1"
+    run "check $req_state $result Test state change to $req_state"
 fi

--- a/testing/state_change
+++ b/testing/state_change
@@ -1,6 +1,6 @@
-if [ $# -lt 1 ] ; then                              
-    echo "usage: sh state_change.sh <required state> (state result)"
-    echo "e.g. sh state_change.sh RESET RESETTING"                  
+if [ $# -ne 1 ] ; then                              
+    echo "usage: sh state_change.sh <required state>"
+    echo "e.g. sh state_change.sh RESET"
     exit                                            
 fi         
 
@@ -12,8 +12,10 @@ echo "Go to state $1"
 eval "caput -S $LLRF_IOC_NAME:MSGS $1 >/dev/null"
 usleep 500000
 result=$(caget -t $LLRF_IOC_NAME)
-if [ $# -eq 1 ]; then 
-    run "check $1 $result 'Test state change to $1'"
+if [ $1 == 'RESET' ]; then 
+	# Special case when state request is 'RESET' as the expected new state is 'RESETTING', allow for this case.
+    run "check RESETTING $result Test state change to $1"
 else
-    run "check $2 $result 'Test state change to $1'"
+	# The norman user case it that the state request matches the expected new state
+    run "check $1 $result Test state change to $1"
 fi


### PR DESCRIPTION
Simplify state_change command to allow for the special case of RESETTING state where expected state name != requested state name.