### PR TITLE
Add a test with odd number of simulated backplane triggers

### DIFF
--- a/testing/test1.sh
+++ b/testing/test1.sh
@@ -90,6 +90,24 @@ done
 result="$(caget -t $LLRF_IOC_NAME:PULSEDONECNT)"
 run "check $result 50 'Test simulating backplane triggers'"
 
+run "state_change 'RESET' 'RESETTING'"
+run "state_change 'INIT'"
+run "state_change 'ON'"
+
+for i in `seq 1 49`
+do
+    echo "Beam Pulse $i"
+    sis8300drv_reg /dev/sis8300-$slot 0x404 -w 0x20
+    sis8300drv_reg /dev/sis8300-$slot 0x404 -w 0x40
+    sis8300drv_reg /dev/sis8300-$slot 0x404 -w 0x80
+    usleep 100000
+done
+
+result="$(caget -t $LLRF_IOC_NAME:PULSEDONECNT)"
+run "check $result 49 'Test simulating backplane triggers'"
+
+
+
 echo 'Revert to INIT state'
 run "state_change 'RESET' 'RESETTING'"
 run "state_change 'INIT'"


### PR DESCRIPTION
This is new test try to get possible errors when IOC goes to RESET
state, after received simulated backplane triggers (in this case
an odd number of it)