### PR TITLE
Test control tables

### DIFF
--- a/testing/test1.sh
+++ b/testing/test1.sh
@@ -145,3 +145,5 @@ done
 
 echo '*** Filters'
 python3 testFilters.py
+echo '*** Control Tables'
+python3 testTables.py

--- a/testing/testFilters.py
+++ b/testing/testFilters.py
@@ -45,7 +45,7 @@ def readReg(board, reg):
     return ret
 
 
-def flot2Qmn(val, m, n, signed):
+def float2Qmn(val, m, n, signed):
     pow_2_frac_bits = float(0x1 << n)
     pow_2_frac_bits_int_bits = float(0x1 << (m + n))
 
@@ -102,9 +102,9 @@ class TestLowPass(unittest.TestCase):
 
         res = self.calc_consts(cutoff, fsamp, n)
 
-        a = flot2Qmn(res[0], 1, 15, 1)
+        a = float2Qmn(res[0], 1, 15, 1)
         self.assertNotEqual(a, nan)
-        b = flot2Qmn(res[1], 1, 15, 1)
+        b = float2Qmn(res[1], 1, 15, 1)
         self.assertNotEqual(b, nan)
         
         a = hex(a)
@@ -151,13 +151,13 @@ class TestNotch(unittest.TestCase):
 
         res = self.calc_consts(bwidth, freq, fsamp, n)
 
-        areal = flot2Qmn(res[0], 1, 15, 1)
+        areal = float2Qmn(res[0], 1, 15, 1)
         self.assertNotEqual(areal, nan)
-        aimag = flot2Qmn(res[1], 1, 15, 1)
+        aimag = float2Qmn(res[1], 1, 15, 1)
         self.assertNotEqual(aimag, nan)
-        breal = flot2Qmn(res[2], 1, 15, 1)
+        breal = float2Qmn(res[2], 1, 15, 1)
         self.assertNotEqual(breal, nan)
-        bimag = flot2Qmn(res[3], 1, 15, 1)
+        bimag = float2Qmn(res[3], 1, 15, 1)
         self.assertNotEqual(bimag, nan)
 
         reg1exp = hex((areal << 16) | aimag)

--- a/testing/testTables.py
+++ b/testing/testTables.py
@@ -4,17 +4,11 @@ import unittest
 from random import random, randint
 from os import system, environ, popen
 
-from testFilters import readReg, getBoard, flot2Qmn
+from testFilters import readReg, getBoard, float2Qmn
 
 NELM = 16
-PREC = 15
 FF_REG="0x41e"
 SP_REG="0x41f"
-M_BITS=1
-N_BITS=15
-
-MIN_VAL=-2**(M_BITS-1)
-MAX_VAL=2**(M_BITS-1) - 2**(-N_BITS)
 
 # Normal mode
 
@@ -30,14 +24,15 @@ MAX_VAL=2**(M_BITS-1) - 2**(-N_BITS)
 # FF - SM - I
 # FF - SM - Q 
 
+def getMinMaxMN(m, n, signed):
+    if signed:
+        min = -2**(m-1)
+        max = 2**(m-1) - 2**(-n)
+    else:
+        min = 0
+        max = (2**m) - (2**(-n))
 
-#epicsFloat32 sis8300llrfControlTableChannel::_FFSPSampleMin =                    
-#         (epicsFloat32) (-pow(2, sis8300llrfdrv_Qmn_IQ_sample.int_bits_m - 1));  
-#                                                                                 
-#epicsFloat32 sis8300llrfControlTableChannel::_FFSPSampleMax =                    
-#         (epicsFloat32) (pow(2, sis8300llrfdrv_Qmn_IQ_sample.int_bits_m - 1) -   
-#                         pow(2, -(int)sis8300llrfdrv_Qmn_IQ_sample.frac_bits_n));
-#
+    return (min, max)
 
 def readMem(board, offset, size):
     p = popen("sis8300drv_mem %s -o %d -n %d" % (board, offset, size))
@@ -46,6 +41,38 @@ def readMem(board, offset, size):
 
     return ret
 
+def set_table(pv_base, ctrl, type, qi, qmn, size = 16):
+    """Set values for one table (the same value)
+    ctrl = SP / FF
+    type = PT0 / SM
+    qi = I / Q
+    size = number of elements
+    qmn = (m, n, signed)
+    """
+
+    (min, max) = getMinMaxMN(*qmn)
+
+    val = round(random()*(max-min)+min, qmn[2])
+    while (val > max or val < min):
+        val = round(random()*(max-min)+min, qmn[2])
+
+    vals = []
+    vals.extend([val]*size)
+    # let on format to caput
+    vals_str = str(size) + " " + (str(vals).replace(",",""))[1:-1]
+    
+    pv = pv_base + ":" + ctrl + "-" + type
+
+    system("caput -a %s %s > /dev/null " % (pv + "-" + qi, vals_str))
+
+    # write table to the memory
+    system("caput %s %d > /dev/null " % (pv + "-WRTBL", 1))
+
+    # update readback
+    system("caput %s %d > /dev/null " % (pv + "-" + qi + "-GET.PROC", 1))
+
+
+    return val
 
 class TestTablesNormal(unittest.TestCase):
     """Class for test tables on Normal mode"""
@@ -53,42 +80,17 @@ class TestTablesNormal(unittest.TestCase):
         super().__init__(*args, **kw)
         self.board = getBoard()
         self.PV = environ.get("LLRF_IOC_NAME") + "1"
-
-    def set_table(self, ctrl, type, qi, size=16):
-        """Set values for one table (the same value)
-        ctrl = SP / FF
-        type = PT0 / SM
-        qi = I / Q
-        size = number of elements
-        """
-        val = round(random()*(MAX_VAL-MIN_VAL)+MIN_VAL, PREC)
-        while (val > MAX_VAL or val < MIN_VAL):
-            val = round(random()*(MAX_VAL-MIN_VAL)+MIN_VAL, PREC)
-
-        vals = []
-        vals.extend([val]*size)
-        # let on format to caput
-        vals_str = str(size) + " " + (str(vals).replace(",",""))[1:-1]
-        
-        pv = self.PV + ":" + ctrl + "-" + type
-
-        system("caput -a %s %s > /dev/null " % (pv + "-" + qi, vals_str))
-
-        # write table to the memory
-        system("caput %s %d > /dev/null " % (pv + "-WRTBL", 1))
-
-        return val
-
+        self.qmn = (1, 15, 1)
 
     def test_tables_sp_qi(self):
-        """Test tables SP Q/I"""
-        q_val = self.set_table("SP", "PT0", "Q")
-        i_val = self.set_table("SP", "PT0", "I")
+        """Test tables SP Q/I on normal mode"""
+        q_val = set_table(self.PV, "SP", "PT0", "Q", self.qmn)
+        i_val = set_table(self.PV, "SP", "PT0", "I", self.qmn)
     
         mem_pos = int(readReg(self.board, SP_REG), NELM)
         mem_values = (readMem(self.board, int(mem_pos/2), NELM*2).split('\n'))[:-1]
-        q_val_qmn = str(flot2Qmn(q_val, 1, 15, 1))
-        i_val_qmn = str(flot2Qmn(i_val, 1, 15, 1))
+        q_val_qmn = str(float2Qmn(q_val, *self.qmn))
+        i_val_qmn = str(float2Qmn(i_val, *self.qmn))
        
         # get a random position to check 
         pos = randint(1, 15)
@@ -99,14 +101,14 @@ class TestTablesNormal(unittest.TestCase):
         self.assertEqual(i_val_qmn, mem_values[pos*2+1])
 
     def test_tables_ff_qi(self):
-        """Test tables FF Q/I"""
-        q_val = self.set_table("FF", "PT0", "Q")
-        i_val = self.set_table("FF", "PT0", "I")
+        """Test tables FF Q/I on normal mode"""
+        q_val = set_table(self.PV, "FF", "PT0", "Q", self.qmn)
+        i_val = set_table(self.PV, "FF", "PT0", "I", self.qmn)
     
         mem_pos = int(readReg(self.board, FF_REG), NELM)
         mem_values = (readMem(self.board, int(mem_pos/2), NELM*2).split('\n'))[:-1]
-        q_val_qmn = str(flot2Qmn(q_val, 1, 15, 1))
-        i_val_qmn = str(flot2Qmn(i_val, 1, 15, 1))
+        q_val_qmn = str(float2Qmn(q_val, *self.qmn))
+        i_val_qmn = str(float2Qmn(i_val, *self.qmn))
        
         # get a random position to check 
         pos = randint(1, 15)
@@ -116,6 +118,89 @@ class TestTablesNormal(unittest.TestCase):
         self.assertEqual(q_val_qmn, mem_values[pos*2])
         self.assertEqual(i_val_qmn, mem_values[pos*2+1])
 
+
+class TestTablesSpecial(unittest.TestCase):
+    """Class for test tables on Normal mode on normal mode"""
+    def __init__(self, *args, **kw):
+        super().__init__(*args, **kw)
+        self.board = getBoard()
+        self.PV = environ.get("LLRF_IOC_NAME") + "1"
+        self.qmn_ang = (3, 13, 1)
+        self.qmn_mag_sp = (0, 16, 0)
+        self.qmn_mag_ff = (1, 15, 1)
+        self.qmn_qi = (1, 15, 1)
+
+    def test_tables_sp_mag_ang(self):
+        """Test tables SP Mag and Ang"""
+        ang_val = set_table(self.PV, "SP", "SM", "ANG", self.qmn_ang)
+        mag_val = set_table(self.PV, "SP", "SM", "MAG", self.qmn_mag_sp)
+    
+        mem_pos = int(readReg(self.board, SP_REG), NELM)
+        mem_values = (readMem(self.board, int(mem_pos/2), NELM*2).split('\n'))[:-1]
+        ang_val_qmn = str(float2Qmn(ang_val, *self.qmn_ang))
+        mag_val_qmn = str(float2Qmn(mag_val, *self.qmn_mag_sp))
+       
+        # get a random position to check 
+        pos = randint(0, 15)
+        # ang pos = pos*2
+        # mag pos = pos*2 + 1
+
+        self.assertEqual(ang_val_qmn, mem_values[pos*2])
+        self.assertEqual(mag_val_qmn, mem_values[pos*2+1])
+
+    def test_tables_ff_mag_ang(self):
+        """Test tables FF Mag and Ang"""
+        ang_val = set_table(self.PV, "FF", "SM", "ANG", self.qmn_ang)
+        mag_val = set_table(self.PV, "FF", "SM", "MAG", self.qmn_mag_ff)
+    
+        mem_pos = int(readReg(self.board, FF_REG), NELM)
+        mem_values = (readMem(self.board, int(mem_pos/2), NELM*2).split('\n'))[:-1]
+        ang_val_qmn = str(float2Qmn(ang_val, *self.qmn_ang))
+        mag_val_qmn = str(float2Qmn(mag_val, *self.qmn_mag_ff))
+       
+        # get a random position to check 
+        pos = randint(0, 15)
+        # q pos = pos*2
+        # i pos = pos*2 + 1
+
+        self.assertEqual(ang_val_qmn, mem_values[pos*2])
+        self.assertEqual(mag_val_qmn, mem_values[pos*2+1])
+
+    def test_tables_sp_qi(self):
+        """Test tables SP Q and I """
+        q_val = set_table(self.PV, "SP", "SM", "Q", self.qmn_qi)
+        i_val = set_table(self.PV, "SP", "SM", "I", self.qmn_qi)
+    
+        mem_pos = int(readReg(self.board, SP_REG), NELM)
+        mem_values = (readMem(self.board, int(mem_pos/2), NELM*2).split('\n'))[:-1]
+        q_val_qmn = str(float2Qmn(q_val, *self.qmn_qi))
+        i_val_qmn = str(float2Qmn(i_val, *self.qmn_qi))
+       
+        # get a random position to check 
+        pos = randint(0, 15)
+        # q pos = pos*2
+        # i pos = pos*2 + 1
+
+        self.assertEqual(q_val_qmn, mem_values[pos*2])
+        self.assertEqual(i_val_qmn, mem_values[pos*2+1])
+
+    def test_tables_ff_qi(self):
+        """Test tables FF Q and I """
+        q_val = set_table(self.PV, "FF", "SM", "Q", self.qmn_qi)
+        i_val = set_table(self.PV, "FF", "SM", "I", self.qmn_qi)
+    
+        mem_pos = int(readReg(self.board, FF_REG), NELM)
+        mem_values = (readMem(self.board, int(mem_pos/2), NELM*2).split('\n'))[:-1]
+        q_val_qmn = str(float2Qmn(q_val, *self.qmn_qi))
+        i_val_qmn = str(float2Qmn(i_val, *self.qmn_qi))
+       
+        # get a random position to check 
+        pos = randint(0, 15)
+        # q pos = pos*2
+        # i pos = pos*2 + 1
+
+        self.assertEqual(q_val_qmn, mem_values[pos*2])
+        self.assertEqual(i_val_qmn, mem_values[pos*2+1])
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/testing/testTables.py
+++ b/testing/testTables.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+
+import unittest
+from random import random, randint
+from os import system, environ, popen
+
+from testFilters import readReg, getBoard, flot2Qmn
+
+NELM = 16
+PREC = 15
+FF_REG="0x41e"
+SP_REG="0x41f"
+M_BITS=1
+N_BITS=15
+
+MIN_VAL=-2**(M_BITS-1)
+MAX_VAL=2**(M_BITS-1) - 2**(-N_BITS)
+
+# Normal mode
+
+# SP - PT0 - I
+# SP - PT0 - Q
+# FF - PT0 - I
+# FF - PT0 - Q 
+
+# Special mode
+
+# SP - SM - I
+# SP - SM - Q
+# FF - SM - I
+# FF - SM - Q 
+
+
+#epicsFloat32 sis8300llrfControlTableChannel::_FFSPSampleMin =                    
+#         (epicsFloat32) (-pow(2, sis8300llrfdrv_Qmn_IQ_sample.int_bits_m - 1));  
+#                                                                                 
+#epicsFloat32 sis8300llrfControlTableChannel::_FFSPSampleMax =                    
+#         (epicsFloat32) (pow(2, sis8300llrfdrv_Qmn_IQ_sample.int_bits_m - 1) -   
+#                         pow(2, -(int)sis8300llrfdrv_Qmn_IQ_sample.frac_bits_n));
+#
+
+def readMem(board, offset, size):
+    p = popen("sis8300drv_mem %s -o %d -n %d" % (board, offset, size))
+    ret = p.read()
+    p.close()
+
+    return ret
+
+
+class TestTablesNormal(unittest.TestCase):
+    """Class for test tables on Normal mode"""
+    def __init__(self, *args, **kw):
+        super().__init__(*args, **kw)
+        self.board = getBoard()
+        self.PV = environ.get("LLRF_IOC_NAME") + "1"
+
+    def set_table(self, ctrl, type, qi, size=16):
+        """Set values for one table (the same value)
+        ctrl = SP / FF
+        type = PT0 / SM
+        qi = I / Q
+        size = number of elements
+        """
+        val = round(random()*(MAX_VAL-MIN_VAL)+MIN_VAL, PREC)
+        while (val > MAX_VAL or val < MIN_VAL):
+            val = round(random()*(MAX_VAL-MIN_VAL)+MIN_VAL, PREC)
+
+        vals = []
+        vals.extend([val]*size)
+        # let on format to caput
+        vals_str = str(size) + " " + (str(vals).replace(",",""))[1:-1]
+        
+        pv = self.PV + ":" + ctrl + "-" + type
+
+        system("caput -a %s %s > /dev/null " % (pv + "-" + qi, vals_str))
+
+        # write table to the memory
+        system("caput %s %d > /dev/null " % (pv + "-WRTBL", 1))
+
+        return val
+
+
+    def test_tables_sp_qi(self):
+        """Test tables SP Q/I"""
+        q_val = self.set_table("SP", "PT0", "Q")
+        i_val = self.set_table("SP", "PT0", "I")
+    
+        mem_pos = int(readReg(self.board, SP_REG), NELM)
+        mem_values = (readMem(self.board, int(mem_pos/2), NELM*2).split('\n'))[:-1]
+        q_val_qmn = str(flot2Qmn(q_val, 1, 15, 1))
+        i_val_qmn = str(flot2Qmn(i_val, 1, 15, 1))
+       
+        # get a random position to check 
+        pos = randint(1, 15)
+        # q pos = pos*2
+        # i pos = pos*2 + 1
+
+        self.assertEqual(q_val_qmn, mem_values[pos*2])
+        self.assertEqual(i_val_qmn, mem_values[pos*2+1])
+
+    def test_tables_ff_qi(self):
+        """Test tables FF Q/I"""
+        q_val = self.set_table("FF", "PT0", "Q")
+        i_val = self.set_table("FF", "PT0", "I")
+    
+        mem_pos = int(readReg(self.board, FF_REG), NELM)
+        mem_values = (readMem(self.board, int(mem_pos/2), NELM*2).split('\n'))[:-1]
+        q_val_qmn = str(flot2Qmn(q_val, 1, 15, 1))
+        i_val_qmn = str(flot2Qmn(i_val, 1, 15, 1))
+       
+        # get a random position to check 
+        pos = randint(1, 15)
+        # q pos = pos*2
+        # i pos = pos*2 + 1
+
+        self.assertEqual(q_val_qmn, mem_values[pos*2])
+        self.assertEqual(i_val_qmn, mem_values[pos*2+1])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)
+


### PR DESCRIPTION
Include tests for control tables.
Part of these tests will fail with current version (the tests related to the special mode).  The test will work correctly with new PR - https://bitbucket.org/europeanspallationsource/m-epics-sis8300llrf/pull-requests/12

This tests are implemented in a python script without extra modules (just standard).
Python was used because the use of float numbers.
The python scripts are not in the best organization, but if this approach is approved I can improve the organization and maybe use petenv (suggested by Control System verification document).